### PR TITLE
fix: Output quick edit link externally

### DIFF
--- a/QuickEdit/quickedit-locatorTool.vm
+++ b/QuickEdit/quickedit-locatorTool.vm
@@ -3,5 +3,6 @@
 
 #set ( $id   = $currentPage.identifier.id )
 #set ( $date = $_DateTool.format("MM/dd/yyyy", $currentPage.lastModified) )
+#set ( $lastUpdatedStr = $_DateTool.format("MM/dd/yyyy", $obj) )
 
-Last updated: <a href="${url}/entity/open.act?type=page&amp;id=${id}#highlight">${date}</a>
+Last updated: [system-view:external]<a href="${url}/entity/open.act?type=page&amp;id=${id}#highlight">${date}</a>[/system-view:external][system-view:internal]${date}[/system-view:internal]

--- a/QuickEdit/quickedit-locatorTool.vm
+++ b/QuickEdit/quickedit-locatorTool.vm
@@ -1,8 +1,5 @@
 ## System URL without a trailing slash
 #set ( $url = "http://localhost:8080" )
-
 #set ( $id   = $currentPage.identifier.id )
 #set ( $date = $_DateTool.format("MM/dd/yyyy", $currentPage.lastModified) )
-#set ( $lastUpdatedStr = $_DateTool.format("MM/dd/yyyy", $obj) )
-
 Last updated: [system-view:external]<a href="${url}/entity/open.act?type=page&amp;id=${id}#highlight">${date}</a>[/system-view:external][system-view:internal]${date}[/system-view:internal]

--- a/QuickEdit/quickedit.vm
+++ b/QuickEdit/quickedit.vm
@@ -1,15 +1,12 @@
 ## System URL without a trailing slash
 #set ( $url = "http://localhost:8080" )
 
-
 ## Get the system-page 'id'
 #set ( $page = $_XPathTool.selectSingleNode($contentRoot, "/system-index-block/calling-page/system-page") )
 #set ( $id = $page.getAttribute("id").value )
 
 ## Get the formatted 'last-modified' date
 #set ( $last = $page.getChild("last-modified").value )
-#set ( $obj  = $_DateTool.getDate($last) )
+#set ( $date = $_DateTool.format("MM/dd/yyyy", $_DateTool.getDate($last)) )
 
-#set ( $link = "${url}/entity/open.act?type=page&amp;id=${id}#highlight" )
-#set ( $lastUpdatedStr = $_DateTool.format("MM/dd/yyyy", $obj) )
-Last updated: [system-view:external]<a href="${link}">${lastUpdatedStr}</a>[/system-view:external][system-view:internal]${lastUpdatedStr}[/system-view:internal]
+Last updated: [system-view:external]<a href="${url}/entity/open.act?type=page&amp;id=${id}#highlight">${date}</a>[/system-view:external][system-view:internal]${date}[/system-view:internal]

--- a/QuickEdit/quickedit.vm
+++ b/QuickEdit/quickedit.vm
@@ -11,5 +11,5 @@
 #set ( $obj  = $_DateTool.getDate($last) )
 
 #set ( $link = "${url}/entity/open.act?type=page&amp;id=${id}#highlight" )
-
-Last updated: <a href="${link}">$_DateTool.format("MM/dd/yyyy", $obj)</a>
+#set ( $lastUpdatedStr = $_DateTool.format("MM/dd/yyyy", $obj) )
+Last updated: [system-view:external]<a href="${link}">${lastUpdatedStr}</a>[/system-view:external][system-view:internal]${lastUpdatedStr}[/system-view:internal]


### PR DESCRIPTION
## Scope

Wrap quick edit link with `[system-view:external]` so Broken Link Report doesn't pick it up.